### PR TITLE
Dropbox support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 docker: clean
 	-docker rm -f ubl
-	docker build --no-cache --tag ubl .
-	docker run -it --name ubl ubl
+	docker build --no-cache --tag voxxit/ubl .
+	docker run -it --name ubl voxxit/ubl
 	docker cp ubl:/usr/src/app/blocklist.txt .
+	docker rm -f ubl
 test: clean
 	python UltimateBlockList.py
 clean:

--- a/README.md
+++ b/README.md
@@ -43,10 +43,7 @@ make docker
      * Note: You can find your config directory [here](https://trac.transmissionbt.com/wiki/ConfigFiles)
      * Your blocklist will be loaded the next time you start Transmission
  * <b>Use a pre-generated list</b>
-     * The list is hosted and available [here](https://gist.github.com/walshie4/6648a23223db413d3b15).
-       Unfortunately the file is so large that gist can't even show the whole thing properly. So you'll have to download
-       it and move it in to position manually. (see above note)
-        * Updated 12/7/2014
+     * The list is hosted and available [here](https://www.dropbox.com/s/2f8irg93zgglh2d/blocklist.txt?dl=1).
  * <b>Setup on a webserver</b>
      * Upload the folder content (or clone this repo) to your webserver
      * Make sure the permission are right (755) for the scripts

--- a/UltimateBlockList.py
+++ b/UltimateBlockList.py
@@ -10,6 +10,13 @@ from bs4 import BeautifulSoup as mksoup
 import gzip
 import os
 
+token = os.getenv('DROPBOX_ACCESS_TOKEN')
+
+if token:
+    from dropbox.client import DropboxClient
+
+    db_client = DropboxClient(token)
+
 BASE = "https://www.iblocklist.com"
 
 def get_value_from(url):
@@ -49,3 +56,8 @@ if __name__=="__main__":
         else:#download and add this sucker
             process(value)
 
+    if token:
+        file = open('blocklist.txt', 'rb')
+        response = db_client.put_file('/blocklist.txt', file, overwrite=True)
+
+        print 'Uploaded to Dropbox!'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4==4.3.2
 requests==2.5.1
+dropbox===2.2.0


### PR DESCRIPTION
I was working on integrating with the Python Dropbox Core API so that one could set up a daily job to generate and upload blocklist.txt to Dropbox.

Build the image with 'make docker', then you can use the image in the crontab at (for example) 5AM daily:

```
0 5 * * * /usr/bin/docker run --rm -it -e DROPBOX_ACCESS_TOKEN="..." ubl
```

I've [set it up already](https://www.dropbox.com/s/2f8irg93zgglh2d/blocklist.txt?dl=1) to do this once a day on a VM of mine for the foreseeable future, but perhaps adding another job somewhere else as a mirror would be cool to ensure it is indeed updated daily.