### PR TITLE
File was still open causing the delete to fail

### DIFF
--- a/UltimateBlockList.py
+++ b/UltimateBlockList.py
@@ -35,11 +35,10 @@ def process(url):
             data = handle.read(1024)
             if len(data) == 0: break
             out.write(data)
-    contents = gzip.GzipFile('ultBlockList.tmp.gz')
-    f = open("blocklist.txt", "a+")#TODO add check for if it exists
-    for line in contents:
-        f.write(line)
-    f.close()
+    with gzip.open('ultBlockList.tmp.gz') as contents:
+        with open("blocklist.txt", "a+") as f:
+            for line in contents:
+                f.write(line)
     os.remove('ultBlockList.tmp.gz')
 
 if __name__=="__main__":


### PR DESCRIPTION
Got the following issue when running the code on Windows:

```
C:\Users\karth\.virtualenvs\ult-blocklist\Scripts\python.exe C:/Users/karth/Projects/Ultimate-Blocklist/UltimateBlockList.py
Getting list page
Downloading Prime blocklist.
Blocklist is not available for free download D:
Downloading Malicious blocklist.
Traceback (most recent call last):
  File "C:/Users/karth/Projects/Ultimate-Blocklist/UltimateBlockList.py", line 62, in <module>
    process(value)
  File "C:/Users/karth/Projects/Ultimate-Blocklist/UltimateBlockList.py", line 43, in process
    os.remove('ultBlockList.tmp.gz')
WindowsError: [Error 32] The process cannot access the file because it is being used by another process: 'ultBlockList.tmp.gz'
```

I've updated the code to use with to open the file so the file handle is released automatically after the file is extracted so deletion can complete successfully. While this fix was done for windows, it should work on both Linux and OSX without any issues.